### PR TITLE
Add the menu to context menu instead of application menu as per norms.

### DIFF
--- a/DFormat.sublime-commands
+++ b/DFormat.sublime-commands
@@ -1,0 +1,3 @@
+[
+	{"caption" : "DFormat: format D code", "command" : "dformat"}
+]

--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -1,0 +1,3 @@
+[
+	{ "keys": ["ctrl+alt+f"], "command": "dformat" }
+]

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -1,0 +1,7 @@
+[
+	{
+		"keys": ["super+.", "super+f"],
+		"command": "dformat",
+		"context": [{ "key": "selector", "operator": "equal", "operand": "source.d" }]
+	}
+]

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -1,36 +1,20 @@
-[
-	{
-		"caption": "Preferences",
-		"mnemonic": "n",
-		"id": "preferences",
-		"children": [
-			{
-				"caption": "Package Settings",
-				"mnemonic": "P",
-				"id": "package-settings",
-				"children": [
-					{
-						"caption": "DFormat",
-						"children": [
-							{
-								"command": "open_file",
-								"args": {"file": "${packages}/DFormat/dformat.sublime-settings"},
-								"caption": "Settings – Default"
-							}
-						]
-					}
-				]
-			}
-		]
-	},
-	{
-		"caption":"DLang",
-		"id": "dlang",
-		"children":
-		[
-			{
-				"caption": "DFormat", "command": "dformat"
-			}
-		]
-	}
+[ { "caption" : "Preferences",
+    "children" : [ { "caption" : "Package Settings",
+          "children" : [ { "caption" : "DFormat",
+                "children" : [ { "args" : { "file" : "${packages}/DFormat/dformat.sublime-settings" },
+                      "caption" : "Settings – Default",
+                      "command" : "open_file"
+                    },
+                    { "args" : { "file" : "${packages}/User/dformat.sublime-settings" },
+                      "caption" : "Settings – User",
+                      "command" : "open_file"
+                    }
+                  ]
+              } ],
+          "id" : "package-settings",
+          "mnemonic" : "P"
+        } ],
+    "id" : "preferences",
+    "mnemonic" : "n"
+  }
 ]

--- a/README.md
+++ b/README.md
@@ -1,18 +1,20 @@
-# Format D source code in Sublime Text
+# `dfmt-sublime` - Format D source code in Sublime Text
 
-## dfmt-sublime
+Integration of [dfmt](https://github.com/Hackerpilot/dfmt) with Sublime Text 2/3.
 
-Integration of [**dfmt**](https://github.com/Hackerpilot/dfmt) with Sublime Text 2/3.
+## Notes
 
-**Note 1:** You need `dfmt` placed in your PATH.
-
-**Note 2:** Specify path to your [.editorconfig](https://github.com/Hackerpilot/dfmt/blob/master/.editorconfig) file (`Preferences` -> `Package Settings` -> `DFormat` -> `Settings - Default`)
-
-**Note 3:** I have only Windows, so can't test it on other systems...
-
-**Note 4:** I have no experience with Python before.
-
+1. You need `dfmt` placed in your PATH.
+2. Specify path to your [.editorconfig](https://github.com/Hackerpilot/dfmt/blob/master/.editorconfig) file (`Preferences` -> `Package Settings` -> `DFormat` -> `Settings - User`)
 
 ## Installation
 
-Please use [Package Control](https://packagecontrol.io/packages/DFormat).
+Use [Package Control](https://packagecontrol.io/packages/DFormat).
+
+
+## Usage
+
+Key-bindings to format the current buffer:
+
+* Windows and Linux - `ctrl+alt+f`
+* Mac - `super+.` followed by `super+f`


### PR DESCRIPTION
Add OS X specific key map;
Add instructions to README for Mac OSX.

Add Linux keymap (duplicate of Windows)
